### PR TITLE
fix(build): pin pnpm version for Vercel via packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "license": "MIT",
+  "packageManager": "pnpm@10.0.0",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",


### PR DESCRIPTION
Vercel was failing with "Error while parsing config file: pnpm-lock.yaml" because the lockfile is lockfileVersion 9.0 (pnpm >=9) but Vercel's default pnpm could not parse it. Declaring packageManager makes Vercel use a compatible pnpm version.